### PR TITLE
fix(fitbit,trakt): more robust auth file handling

### DIFF
--- a/fitbit.py
+++ b/fitbit.py
@@ -184,9 +184,11 @@ def fetch_activities(date):
 connect(FITBIT_DATABASE)
 
 if not FITBIT_ACCESS_TOKEN:
-    if os.path.isfile('.fitbit-refreshtoken'):
-        f = open(".fitbit-refreshtoken", "r")
-        token = f.read()
+    script_dir = os.path.dirname(__file__)
+    refresh_token_path = os.path.join(script_dir, '.fitbit-refreshtoken')
+    if os.path.isfile(refresh_token_path):
+        f = open(refresh_token_path, "r")
+        token = f.read().strip()
         f.close()
         response = requests.post('https://api.fitbit.com/oauth2/token',
             data={
@@ -209,7 +211,7 @@ if not FITBIT_ACCESS_TOKEN:
     json = response.json()
     FITBIT_ACCESS_TOKEN = json['access_token']
     refresh_token = json['refresh_token']
-    f = open(".fitbit-refreshtoken", "w+")
+    f = open(refresh_token_path, "w+")
     f.write(refresh_token)
     f.close()
 

--- a/trakt-tv.py
+++ b/trakt-tv.py
@@ -52,12 +52,14 @@ Trakt.configuration.defaults.client(
 	secret=TRAKT_CLIENT_SECRET
 )
 
-if not os.path.exists(".trakt.json"):
+script_dir = os.path.dirname(__file__)
+oauth_config_file = os.path.join(script_dir, '.trakt.json')
+if not os.path.exists(oauth_config_file):
 	auth = Trakt['oauth'].token_exchange(TRAKT_OAUTH_CODE, 'urn:ietf:wg:oauth:2.0:oob')
-	with open('.trakt.json', 'w') as outfile:
+	with open(oauth_config_file, 'w') as outfile:
 		json.dump(auth, outfile)
 else:
-	with open('.trakt.json') as json_file:
+	with open(oauth_config_file) as json_file:
 		auth = json.load(json_file)
 
 Trakt.configuration.defaults.oauth.from_response(auth)


### PR DESCRIPTION
Before this change, `python /whatever/personal-influxdb/fitbit.py` created auth files like `/whatever/.fitbit-refreshtoken`, instead of `/whatever/personal-influxdb/.fitbit-refreshtoken`.

Now, the token will always be next to the script, independent of where it's being called from.

I only patched these two integrations as that's all I set up and could test.