### PR TITLE
Add Docker and Kubernetes Examples

### DIFF
--- a/docker-example/Dockerfile-librelinkup
+++ b/docker-example/Dockerfile-librelinkup
@@ -1,0 +1,27 @@
+FROM python:3.11.4-alpine3.18
+
+LABEL maintainer="Evan Richardson (evanrich81[at]gmail.com)"
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Copy the requirements.txt file into the container at /app
+COPY requirements.txt /app/
+
+# Install the Python dependencies specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the link.py and config.py files to the root directory
+COPY librelinkup.py /
+COPY config.py /
+
+ENV INFLUXDB_HOST="default_host"
+ENV INFLUXDB_PORT="default_port"
+ENV INFLUXDB_USER="default_username"
+ENV INFLUXDB_PASSWORD="default_password"
+ENV LIBRELINKUP_DATABASE="database"
+ENV LIBRELINKUP_USERNAME="librelinkup_username"
+ENV LIBRELINKUP_PASSWORD="librelinkup_password"
+
+# Run the Python script link.py
+CMD ["python", "/librelinkup.py"]

--- a/docker-example/README.md
+++ b/docker-example/README.md
@@ -1,0 +1,41 @@
+## Dockerfile
+You can obviously customize this however you want, and likely will.   I wrote this quick and dirty to extract all the parameters I needed for the librelinkup and config python files to work.  You can add/delete as necessary.
+
+Breaking the file down:
+
+`FROM python:3.11.4-alpine3.18`
+###### this  defines the base image to use.  I wanted to keep things nice and tidy, so I used the python 3.11 image based on alpine 3.18.  you can use whatever you want.
+
+`LABEL maintainer="Evan Richardson (evanrich81[at]gmail.com)"`
+###### **The maintainer of the image.  I posted this to dockerhub, so I stuck my name and email on there, please don't spam me.  You can change to whatever you want.**
+
+`WORKDIR /app`
+###### This sets the working directory for the container to `/app`
+
+`COPY requirements.txt /app/` 
+###### Self explanitory.
+
+`RUN pip install --no-cache-dir -r requirements.txt`
+###### Installs the requirements, leaving no cache behind (smaller final image)
+
+    COPY librelinkup.py /
+    COPY config.py /
+###### These lines copy the python files to the root directory (could go in app if you wanted).  These could also be consolidated on one line for one less layer, but not the end of the world.
+ 
+
+    ENV INFLUXDB_HOST="default_host"
+    ENV INFLUXDB_PORT="default_port"
+    ENV INFLUXDB_USER="default_username" 
+    ENV INFLUXDB_PASSWORD="default_password"
+    ENV LIBRELINKUP_DATABASE="database"
+    ENV LIBRELINKUP_USERNAME="librelinkup_username" 
+    ENV LIBRELINKUP_PASSWORD="librelinkup_password"
+##### This block of env variables defines env variables that will be available to the container.  Set these to whatever you want.
+
+`CMD ["python", "/librelinkup.py"]`
+##### And finally, the run line.  This runs the selected python file upon start of the container.
+
+
+## Running the container
+If you use the cronjob in the kubernetes folder, it will add the environmental variables automatically.  if not, then you should run this image in a way similar to:
+`docker run -e VAR1=VALUE1 -e VAR2=VALUE  evanrich/libre2influx:latest`

--- a/docker-example/config.py
+++ b/docker-example/config.py
@@ -1,0 +1,94 @@
+#!/usr/bin/python3
+# Copyright 2022 Sam Steele
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys, logging, colorlog, pytz, os
+from influxdb import InfluxDBClient
+from influxdb.exceptions import InfluxDBClientError
+
+TIMEZONE = os.getenv('TZ', 'America/Los_Angeles')
+LOCAL_TIMEZONE = pytz.timezone(TIMEZONE)
+
+# InfluxDB Configuration
+INFLUXDB_HOST = os.getenv('INFLUXDB_HOST')
+INFLUXDB_PORT = os.getenv('INFLUXDB_PORT', 8086)
+INFLUXDB_USERNAME = os.getenv('INFLUXDB_USER', 'admin')
+INFLUXDB_PASSWORD = os.getenv('INFLUXDB_PASSWORD', 'admin')
+INFLUXDB_CHUNK_SIZE = 50 # How many points to send per request
+
+# Freestyle LibreLinkUp configuration
+LIBRELINKUP_USERNAME = os.getenv('LIBRELINKUP_USERNAME')
+LIBRELINKUP_PASSWORD = os.getenv('LIBRELINKUP_PASSWORD')
+LIBRELINKUP_DATABASE = os.getenv('LIBRELINKUP_DATABASE')
+LIBRELINKUP_URL = 'https://api-us.libreview.io'
+LIBRELINKUP_VERSION = '4.7.0'
+LIBRELINKUP_PRODUCT = 'llu.ios'
+
+# Logging configuration
+LOG_LEVEL = logging.INFO
+LOG_FORMAT = '%(asctime)s %(log_color)s%(message)s'
+LOG_COLORS = {
+    'WARNING':  'yellow',
+    'ERROR':    'red',
+    'CRITICAL': 'red',
+        }
+
+def connect(db):
+    global client
+    try:
+        logging.info("Connecting to %s:%s", INFLUXDB_HOST, INFLUXDB_PORT)
+        client = InfluxDBClient(host=INFLUXDB_HOST, port=INFLUXDB_PORT, username=INFLUXDB_USERNAME, password=INFLUXDB_PASSWORD)
+        client.create_database(db)
+        client.switch_database(db)
+    except InfluxDBClientError as err:
+        logging.error("InfluxDB connection failed: %s", err)
+        sys.exit(1)
+    return client
+
+def write_points(points):
+    total = len(points)
+    global client
+    try:
+        start = 0
+        end = INFLUXDB_CHUNK_SIZE
+        while start < len(points):
+            if end > len(points):
+                end = len(points)
+
+            client.write_points(points[start:end])
+            logging.debug(f"Wrote {end} / {total} points")
+
+            start = end
+            end = end + INFLUXDB_CHUNK_SIZE
+    except InfluxDBClientError as err:
+        logging.error("Unable to write points to InfluxDB: %s", err)
+        sys.exit(1)
+
+    logging.info("Successfully wrote %s data points to InfluxDB", total)
+
+client = None
+
+if sys.stdout.isatty():
+    colorlog.basicConfig(level=LOG_LEVEL, format=LOG_FORMAT, log_colors=LOG_COLORS, stream=sys.stdout)
+else:
+    logging.basicConfig(level=LOG_LEVEL, format=LOG_FORMAT.replace(f'%(log_color)s', ''), stream=sys.stdout)
+
+def handle_exception(exc_type, exc_value, exc_traceback):
+    if issubclass(exc_type, KeyboardInterrupt):
+        sys.__excepthook__(exc_type, exc_value, exc_traceback)
+        return
+
+    logging.critical("Uncaught exception:", exc_info=(exc_type, exc_value, exc_traceback))
+
+sys.excepthook = handle_exception

--- a/docker-example/librelinkup.py
+++ b/docker-example/librelinkup.py
@@ -1,0 +1,108 @@
+#!/usr/bin/python3
+# Copyright 2022 Sam Steele
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import requests, sys, os, json, time
+from datetime import datetime
+from config import *
+
+def append_reading(points, data, reading):
+    time = datetime.strptime(reading['FactoryTimestamp'] + '+00:00', '%m/%d/%Y %I:%M:%S %p%z')
+    points.append({
+        "measurement": "glucose",
+        "time": time,
+        "tags": {
+            "deviceType": "Libre",
+            "deviceSerialNumber": data['data']['connection']['sensor']['sn'],
+        },
+        "fields": {
+            "value": int(reading['ValueInMgPerDl']),
+            "units": 'mg/dL',
+        }
+    })
+
+if not LIBRELINKUP_USERNAME:
+    logging.error("LIBRELINKUP_USERNAME not set in config.py")
+    sys.exit(1)
+
+points = []
+
+connect(LIBRELINKUP_DATABASE)
+
+LIBRELINKUP_HEADERS = {
+    "version": LIBRELINKUP_VERSION,
+    "product": LIBRELINKUP_PRODUCT,
+}
+
+LIBRELINKUP_TOKEN = None
+script_dir = os.path.dirname(__file__)
+auth_token_path = os.path.join(script_dir, '.librelinkup-authtoken')
+if os.path.isfile(auth_token_path):
+    with open(auth_token_path) as json_file:
+            auth = json.load(json_file)
+            if auth['expires'] > time.time():
+                LIBRELINKUP_TOKEN = auth['token']
+                logging.info("Using cached authTicket, expiration: %s", datetime.fromtimestamp(auth['expires']).isoformat())
+
+if LIBRELINKUP_TOKEN is None:
+    logging.info("Auth ticket not found or expired, requesting a new one")
+    try:
+        response = requests.post(f'{LIBRELINKUP_URL}/llu/auth/login',
+            headers=LIBRELINKUP_HEADERS, json = {'email': LIBRELINKUP_USERNAME, 'password': LIBRELINKUP_PASSWORD})
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as err:
+        logging.error("HTTP request failed: %s", err)
+        sys.exit(1)
+
+    data = response.json()
+    if not 'authTicket' in data['data']:
+        logging.error("Authentication failed")
+        sys.exit(1)
+
+    with open(auth_token_path, 'w') as outfile:
+        json.dump(data['data']['authTicket'], outfile)
+
+    LIBRELINKUP_TOKEN = data['data']['authTicket']['token']
+
+LIBRELINKUP_HEADERS['Authorization'] = 'Bearer ' + LIBRELINKUP_TOKEN
+
+try:
+    response = requests.get(f'{LIBRELINKUP_URL}/llu/connections', headers=LIBRELINKUP_HEADERS)
+    response.raise_for_status()
+except requests.exceptions.HTTPError as err:
+    logging.error("HTTP request failed: %s", err)
+    sys.exit(1)
+
+connections = response.json()
+if not 'data' in connections or len(connections['data']) < 1:
+    logging.error("No connections configured. Accept an invitation in the mobile app first.")
+    sys.exit(1)
+
+logging.info("Using connection %s: %s %s", connections['data'][0]['patientId'], connections['data'][0]['firstName'], connections['data'][0]['lastName'])
+
+try:
+    response = requests.get(f'{LIBRELINKUP_URL}/llu/connections/{connections["data"][0]["patientId"]}/graph', headers=LIBRELINKUP_HEADERS)
+    response.raise_for_status()
+except requests.exceptions.HTTPError as err:
+    logging.error("HTTP request failed: %s", err)
+    sys.exit(1)
+
+data = response.json()
+append_reading(points, data, data['data']['connection']['glucoseMeasurement'])
+
+if len(data['data']['graphData']) > 0:
+    for reading in data['data']['graphData']:
+        append_reading(points, data, reading)
+
+write_points(points)

--- a/docker-example/requirements.txt
+++ b/docker-example/requirements.txt
@@ -1,0 +1,4 @@
+influxdb==5.3.1
+requests==2.25.1
+colorlog==6.7.0
+pytz==2023.3

--- a/k8s-example/README.md
+++ b/k8s-example/README.md
@@ -1,0 +1,10 @@
+## Secrets
+The Kubernetes manifests here are pretty straight forward.  I personally use [external-secrets](https://external-secrets.io/v0.8.5/) with [doppler.com](https://doppler.com) to manage my secrets outside the cluster, but you can use a regular old kubernetes secret if you want.  I've included examples for both.  Obviously depending on which python file you're using and how you modify the config.py, you may need to rename/change/add/delete from here.
+
+Simply use the secret/external-secret examples as a starting point, and then apply with `kubectl apply -f secret.yaml` and you should be good to go.
+
+## Cron Job
+The cronjob example runs the image at a preset time.  I have mine currently set to run every hour, where it grabs librelinkup data for my pet's blood sugar monitor.  You can customize as necessary, then same as the secret, deploy with `kubectl apply -f cronjob.yaml` or your favorite automation tool of choice.  I use ArgoCD and have a manifest for that to deploy  into my cluster.
+
+
+> Written with [StackEdit](https://stackedit.io/).

--- a/k8s-example/cronjob-example.yaml
+++ b/k8s-example/cronjob-example.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: freelibre-cron
+  namespace: default
+spec:
+  schedule: "0 */1 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app: freelibre-job
+        spec:
+          containers:
+          - name: freelibre-upload-cron
+            image: evanrich/freelibre2influx:latest
+            imagePullPolicy: IfNotPresent
+            envFrom:
+            - secretRef:
+                name: freestyle-secrets
+          restartPolicy: OnFailure

--- a/k8s-example/external-secret-example.yaml
+++ b/k8s-example/external-secret-example.yaml
@@ -1,0 +1,33 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: freestyle-secrets
+  namespace: default
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler
+  target:
+    name: freestyle-secrets
+  data:
+    - secretKey: INFLUXDB_HOST
+      remoteRef:
+        key: INFLUXDB_HOST
+    - secretKey: INFLUXDB_PORT
+      remoteRef:
+        key: INFLUXDB_PORT
+    - secretKey: INFLUXDB_USERNAME
+      remoteRef:
+        key: INFLUXDB_ADMIN_USER
+    - secretKey: INFLUXDB_PASSWORD
+      remoteRef:
+        key: INFLUXDB_ADMIN_PASSWORD
+    - secretKey: LIBRELINKUP_USERNAME
+      remoteRef:
+        key: LIBRELINKUP_USERNAME
+    - secretKey: LIBRELINKUP_PASSWORD
+      remoteRef:
+        key: LIBRELINKUP_PASSWORD
+    - secretKey: LIBRELINKUP_DATABASE
+      remoteRef:
+        key: LIBRELINKUP_DATABASE

--- a/k8s-example/secret-example.yaml
+++ b/k8s-example/secret-example.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:  
+  name: freestyle-secrets
+type: Opaque
+data:
+  INFLUXDB_HOST: dXNlcg==
+  INFLUXDB_PORT: dXNlcg==
+  INFLUXDB_ADMIN_USER: dXNlcg==
+  INFLUXDB_ADMIN_PASSWORD: dXNlcg==
+  LIBRELINKUP_USERNAME: dXNlcg==
+  LIBRELINKUP_PASSWORD: dXNlcg==
+  LIBRELINKUP_DATABASE: dXNlcg==


### PR DESCRIPTION
I run a kubernetes cluster in my homelab, and wanted a way to monitor my pet's blood sugar levels.  I found @c99koder 's repo, which worked perfectly, but only contained the python files.   I threw together a custom docker image for the librelinkup code, threw together a set of manifests, and deployed it in my cluster as a CronJob that runs on the to load data into Influx, and eventually graph in Grafana.  

I am sharing the code I used, along with README files that describe the code, in hopes that it might help others.  Obviously the examples are geared towards the librelinkup code, but you can modify them as needed for other files as you see fit, use them as a template.  Hopefully these will save others time  if they decide to do the same thing.

Enjoy