### PR TITLE
LibreLinkUp: add logging when server region is incorrect

### DIFF
--- a/librelinkup.py
+++ b/librelinkup.py
@@ -67,7 +67,11 @@ if LIBRELINKUP_TOKEN is None:
 
     data = response.json()
     if not 'authTicket' in data['data']:
-        logging.error("Authentication failed")
+        logging.error("Authentication failed. Server response:")
+        logging.info(data)
+        if 'redirect' in data['data'] and data['data']['redirect'] is True:
+            region = data['data']['region']
+            logging.error(f"The LibreLinkUp API returned a redirect. You should try the following url for LIBRELINKUP_URL in config.py: https://api-{region}.libreview.io")
         sys.exit(1)
 
     with open(auth_token_path, 'w') as outfile:


### PR DESCRIPTION
Apparently, the LibreLinkUp API has many regions and accounts are expected to use their region-specific API. In such a case, all other regions return a redirect.

Example log output:
```
2023-12-17 11:37:08,662 Connecting to 192.168.178.20:8086
2023-12-17 11:37:08,692 Auth ticket not found or expired, requesting a new one
2023-12-17 11:37:09,888 Authentication failed. Server response:
2023-12-17 11:37:09,890 {'status': 0, 'data': {'redirect': True, 'region': 'de'}}
2023-12-17 11:37:09,891 The LibreLinkUp API returned a redirect. You should try the following url for LIBRELINKUP_URL in config.py: https://api-de.libreview.io
```